### PR TITLE
Add central circle tool for concentric map distances

### DIFF
--- a/central-circle/index.html
+++ b/central-circle/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Central Circle</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-XQoYMqMTK8LpG72KXWDSA3yxg0BQwH3jzLFb4rJZzOE=" crossorigin="">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
   <style>*{box-sizing:border-box}
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
@@ -17,6 +17,36 @@
   }
   header {
     padding: 1.5rem 1rem 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .header-content {
+    flex: 1;
+  }
+  .unit-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: white;
+    border: 2px solid #222;
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .unit-toggle label {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .unit-toggle input[type="checkbox"] {
+    cursor: pointer;
+    width: 18px;
+    height: 18px;
   }
   h1 {
     margin: 0 0 .5rem;
@@ -48,62 +78,147 @@
   a {
     color: #0645ad;
   }
+  .ring-label-marker {
+    background: transparent;
+    border: none;
+  }
+  .ring-label {
+    background: rgba(255, 255, 255, 0.9);
+    border: 2px solid #222;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-weight: 600;
+    font-size: 14px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    white-space: nowrap;
+  }
   </style>
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kPppZP2hYhi3F7S0Qe8kPC58LFvH+Sl5vj50Y=" crossorigin="" defer></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
 </head>
 <body>
   <header>
-    <h1>Central Circle</h1>
-    <p>Click anywhere on the map to draw concentric distance rings around that point. Use this to visualise approximate travel radiuses or service areas.</p>
+    <div class="header-content">
+      <h1>Central Circle</h1>
+      <p id="description">Click anywhere on the map to draw concentric distance rings around that point. Circles are drawn at 50, 100, 200, 300 kilometres</p>
+    </div>
+    <div class="unit-toggle">
+      <label>
+        <input type="checkbox" id="unitToggle" aria-label="Toggle between kilometres and miles">
+        <span id="unitLabel">Miles</span>
+      </label>
+    </div>
   </header>
   <main>
     <div id="map" role="region" aria-label="Interactive map for drawing concentric circles"></div>
   </main>
   <footer>
-    Distances are set in kilometres and can be adjusted in the script below.
+    
   </footer>
-  <script type="module">
-const map = L.map('map', {
-  center: [20, 0],
-  zoom: 2,
-  worldCopyJump: true
-});
-
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  maxZoom: 18,
-  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-}).addTo(map);
-
-// Distances in kilometres for each concentric ring.
-const ringDistancesKm = [50, 100, 200, 300];
-
-const markerLayer = L.layerGroup().addTo(map);
-const ringsLayer = L.layerGroup().addTo(map);
-
-function drawCentralRings(latlng) {
-  markerLayer.clearLayers();
-  ringsLayer.clearLayers();
-
-  L.marker(latlng, { title: 'Selected centre' }).addTo(markerLayer);
-
-  ringDistancesKm.forEach(distanceKm => {
-    const radiusMeters = distanceKm * 1000;
-    L.circle(latlng, {
-      radius: radiusMeters,
-      color: '#222',
-      weight: 2,
-      fillColor: '#2b8a3e',
-      fillOpacity: 0.1
-    }).bindTooltip(`${distanceKm} km`, { permanent: false }).addTo(ringsLayer);
+  <script>
+document.addEventListener('DOMContentLoaded', function() {
+  // Initialize the map
+  const map = L.map('map', {
+    center: [20, 0],
+    zoom: 2,
+    worldCopyJump: true
   });
-}
 
-map.on('click', event => {
-  drawCentralRings(event.latlng);
+  // Add OpenStreetMap tile layer
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 18,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  }).addTo(map);
+
+  // Distances in kilometres for each concentric ring.
+  const ringDistancesKm = [50, 100, 200, 300];
+  
+  // Unit system: true = miles, false = kilometres
+  let useMiles = false;
+  
+  // Get DOM elements
+  const unitToggle = document.getElementById('unitToggle');
+  const unitLabel = document.getElementById('unitLabel');
+  const description = document.getElementById('description');
+  
+  function updateDescription() {
+    const distances = useMiles 
+      ? [31, 62, 124, 186]  // Approximate mile equivalents
+      : [50, 100, 200, 300];
+    const unit = useMiles ? 'miles' : 'kilometres';
+    description.textContent = `Click anywhere on the map to draw concentric distance rings around that point. Circles are drawn at ${distances.join(', ')} ${unit}`;
+  }
+  
+  unitToggle.addEventListener('change', function() {
+    useMiles = this.checked;
+    unitLabel.textContent = useMiles ? 'Miles' : 'Km';
+    updateDescription();
+    // Redraw rings if they exist
+    if (markerLayer.getLayers().length > 0) {
+      const centerMarker = markerLayer.getLayers()[0];
+      drawCentralRings(centerMarker.getLatLng());
+    }
+  });
+
+  const markerLayer = L.layerGroup().addTo(map);
+  const ringsLayer = L.layerGroup().addTo(map);
+
+  function drawCentralRings(latlng) {
+    markerLayer.clearLayers();
+    ringsLayer.clearLayers();
+
+    L.marker(latlng, { title: 'Selected centre' }).addTo(markerLayer);
+
+    ringDistancesKm.forEach(distanceKm => {
+      const radiusMeters = distanceKm * 1000;
+      const circle = L.circle(latlng, {
+        radius: radiusMeters,
+        color: '#222',
+        weight: 2,
+        fillColor: '#2b8a3e',
+        fillOpacity: 0.1
+      }).addTo(ringsLayer);
+
+      // Calculate a point on the circle (45 degrees / northeast)
+      const earthRadius = 6371000; // meters
+      const bearing = 45; // degrees
+      const lat1 = latlng.lat * Math.PI / 180;
+      const lon1 = latlng.lng * Math.PI / 180;
+      const angularDistance = radiusMeters / earthRadius;
+      const bearingRad = bearing * Math.PI / 180;
+
+      const lat2 = Math.asin(
+        Math.sin(lat1) * Math.cos(angularDistance) +
+        Math.cos(lat1) * Math.sin(angularDistance) * Math.cos(bearingRad)
+      );
+      const lon2 = lon1 + Math.atan2(
+        Math.sin(bearingRad) * Math.sin(angularDistance) * Math.cos(lat1),
+        Math.cos(angularDistance) - Math.sin(lat1) * Math.sin(lat2)
+      );
+
+      const labelPosition = L.latLng(lat2 * 180 / Math.PI, lon2 * 180 / Math.PI);
+
+      // Convert to appropriate unit for display
+      const displayDistance = useMiles ? (distanceKm * 0.621371).toFixed(0) : distanceKm;
+      const unit = useMiles ? 'mi' : 'km';
+
+      // Add label marker at the calculated position
+      L.marker(labelPosition, {
+        icon: L.divIcon({
+          className: 'ring-label-marker',
+          html: `<div class="ring-label">${displayDistance} ${unit}</div>`,
+          iconSize: null
+        })
+      }).addTo(ringsLayer);
+    });
+  }
+
+  map.on('click', event => {
+    drawCentralRings(event.latlng);
+  });
+
+  // Provide an initial example so users see the behaviour immediately.
+  drawCentralRings(map.getCenter());
 });
-
-// Provide an initial example so users see the behaviour immediately.
-drawCentralRings(map.getCenter());
   </script>
 </body>
 </html>

--- a/central-circle/index.html
+++ b/central-circle/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Central Circle</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-XQoYMqMTK8LpG72KXWDSA3yxg0BQwH3jzLFb4rJZzOE=" crossorigin="">
+  <style>*{box-sizing:border-box}
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    margin: 0;
+    background: #f7f7f7;
+    color: #111;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  header {
+    padding: 1.5rem 1rem 0;
+  }
+  h1 {
+    margin: 0 0 .5rem;
+    font-size: 1.75rem;
+  }
+  p {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+  main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0 1rem 1.5rem;
+  }
+  #map {
+    flex: 1;
+    min-height: 420px;
+    border: 2px solid #222;
+    border-radius: 8px;
+  }
+  footer {
+    font-size: .9rem;
+    color: #444;
+    padding: 0 1rem 1.5rem;
+  }
+  a {
+    color: #0645ad;
+  }
+  </style>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kPppZP2hYhi3F7S0Qe8kPC58LFvH+Sl5vj50Y=" crossorigin="" defer></script>
+</head>
+<body>
+  <header>
+    <h1>Central Circle</h1>
+    <p>Click anywhere on the map to draw concentric distance rings around that point. Use this to visualise approximate travel radiuses or service areas.</p>
+  </header>
+  <main>
+    <div id="map" role="region" aria-label="Interactive map for drawing concentric circles"></div>
+  </main>
+  <footer>
+    Distances are set in kilometres and can be adjusted in the script below.
+  </footer>
+  <script type="module">
+const map = L.map('map', {
+  center: [20, 0],
+  zoom: 2,
+  worldCopyJump: true
+});
+
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 18,
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map);
+
+// Distances in kilometres for each concentric ring.
+const ringDistancesKm = [50, 100, 200, 300];
+
+const markerLayer = L.layerGroup().addTo(map);
+const ringsLayer = L.layerGroup().addTo(map);
+
+function drawCentralRings(latlng) {
+  markerLayer.clearLayers();
+  ringsLayer.clearLayers();
+
+  L.marker(latlng, { title: 'Selected centre' }).addTo(markerLayer);
+
+  ringDistancesKm.forEach(distanceKm => {
+    const radiusMeters = distanceKm * 1000;
+    L.circle(latlng, {
+      radius: radiusMeters,
+      color: '#222',
+      weight: 2,
+      fillColor: '#2b8a3e',
+      fillOpacity: 0.1
+    }).bindTooltip(`${distanceKm} km`, { permanent: false }).addTo(ringsLayer);
+  });
+}
+
+map.on('click', event => {
+  drawCentralRings(event.latlng);
+});
+
+// Provide an initial example so users see the behaviour immediately.
+drawCentralRings(map.getCenter());
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
   <!-- TOOLS-LIST START -->
 <ul>
   <li><a href="Workflow-to-GPX/">Workflow-to-GPX</a></li>
+  <li><a href="central-circle/">central-circle</a></li>
   <li><a href="nutri-calculator/">nutri-calculator</a></li>
 </ul>
 <!-- TOOLS-LIST END -->


### PR DESCRIPTION
## Summary
- add a new central-circle tool that draws concentric distance rings on a Leaflet map
- initialize the map with OpenStreetMap tiles and configurable distance steps
- update the root index to list the new tool

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e049cb5234832a86560369e1ebefbb