### PR TITLE
Add minimal static HTTP server and README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Tools are automatically discovered and listed by scanning for directories in the
 2. **Use a tool**: Click on any tool name to open it
 3. **Run locally**: Clone the repository and open `index.html` in a web browser
 4. **Add a tool**: Create a new directory with an `index.html` file following the guidelines in `RULES.md`
+5. **Serve locally**: Run `uv run serve.py --port 8000` to start a static HTTP server for the repo
 
 ## License
 

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Serve the repo with a tiny static HTTP server."""
+from __future__ import annotations
+
+import argparse
+import functools
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(
+    description="Serve the repository over a static HTTP server."
+  )
+  parser.add_argument(
+    "--host",
+    default="127.0.0.1",
+    help="Host address to bind (default: 127.0.0.1).",
+  )
+  parser.add_argument(
+    "--port",
+    type=int,
+    default=8000,
+    help="Port to bind (default: 8000).",
+  )
+  parser.add_argument(
+    "--directory",
+    default=".",
+    help="Directory to serve (default: current directory).",
+  )
+  return parser
+
+
+def main() -> None:
+  parser = build_parser()
+  args = parser.parse_args()
+  directory = Path(args.directory).resolve()
+  if not directory.is_dir():
+    parser.error(f"{directory} is not a directory")
+
+  handler = functools.partial(SimpleHTTPRequestHandler, directory=str(directory))
+  server = ThreadingHTTPServer((args.host, args.port), handler)
+  print(f"Serving {directory} at http://{args.host}:{args.port}")
+  try:
+    server.serve_forever()
+  except KeyboardInterrupt:
+    print("\nShutting down.")
+  finally:
+    server.server_close()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
### Motivation
- Provide a basic, minimal static HTTP server so the repository can be served locally for tool smoke tests and for Codex-driven build/test runs.
- Keep to repository conventions for one-file Python tools (fast startup, minimal deps, runnable via `uv run`).

### Description
- Add `serve.py`, a tiny static server using `ThreadingHTTPServer` and `SimpleHTTPRequestHandler` with `--host`, `--port`, and `--directory` arguments. 
- Include PEP-723/`uv` header metadata so the script can be run with `uv run serve.py`.
- Update `README.md` to document running the server with `uv run serve.py --port 8000`.
- No skills from the AGENTS.md skill list were used because the change is a straightforward repository tooling addition.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821e9b82d4832abfcf7a6ef9fb24aa)