### PR TITLE
fix: offset clock hand by -90deg so it starts at top

### DIFF
--- a/quarters-of-the-year/index.html
+++ b/quarters-of-the-year/index.html
@@ -354,8 +354,8 @@ function update() {
   const elapsed = (now - start) / 86400000;
   const progress = elapsed / totalDays;
 
-  // Clock hand: 0 = top (Q1 start), rotates clockwise 360deg over the year
-  const angle = progress * 360;
+  // Clock hand: -90deg = top (Q1 start), rotates clockwise 360deg over the year
+  const angle = -90 + progress * 360;
   document.querySelector(".clock-hand").style.setProperty("--hand-angle", `${angle}deg`);
 
   // Progress ring


### PR DESCRIPTION
The hand now starts at 12 o'clock (top of the grid) for January and rotates clockwise through the year. February correctly points slightly right of top, into the Q1 quadrant.

https://claude.ai/code/session_01AdEy6KCmVdwCxCWAkjTN8C