### PR TITLE
Improve image loading UX with fade-in and crossfade transitions

### DIFF
--- a/webcam-image-viewer/index.html
+++ b/webcam-image-viewer/index.html
@@ -117,6 +117,21 @@
       transition: opacity 0.3s ease;
     }
 
+    .tile-image-wrap img:not([src]) {
+      visibility: hidden;
+    }
+
+    .tile-crossfade-overlay {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+      opacity: 0;
+      transition: opacity 0.8s ease;
+    }
+
     .tile-image-wrap .gif-layer {
       position: absolute;
       inset: 0;
@@ -699,28 +714,67 @@ async function loadTileImage(webcam) {
   if (!tile) return;
 
   const loading = tile.querySelector('.tile-loading-overlay');
+  const imageWrap = tile.querySelector('.tile-image-wrap');
   const jpgImg = tile.querySelector('.jpg-layer');
   const gifImg = tile.querySelector('.gif-layer');
   const existingError = tile.querySelector('.tile-error-overlay');
   if (existingError) existingError.remove();
-  if (loading) loading.hidden = false;
+
+  const hasExistingImage = jpgImg.hasAttribute('src');
+  if (!hasExistingImage && loading) loading.hidden = false;
 
   try {
     const data = await fetchSnapshot(webcam.snapshotUrl);
     tileData.set(webcam.id, data);
 
-    jpgImg.src = data.jpgUrl;
-    if (data.gifUrl) {
-      gifImg.src = data.gifUrl;
-    }
+    if (!hasExistingImage) {
+      // First load: fade image in once loaded
+      jpgImg.style.opacity = '0';
+      jpgImg.src = data.jpgUrl;
+      if (data.gifUrl) gifImg.src = data.gifUrl;
 
-    jpgImg.onload = () => {
-      if (loading) loading.hidden = true;
-    };
-    jpgImg.onerror = () => {
-      if (loading) loading.hidden = true;
-      showTileError(tile, webcam);
-    };
+      jpgImg.onload = () => {
+        if (loading) loading.hidden = true;
+        requestAnimationFrame(() => { jpgImg.style.opacity = '1'; });
+      };
+      jpgImg.onerror = () => {
+        if (loading) loading.hidden = true;
+        showTileError(tile, webcam);
+      };
+    } else {
+      // Subsequent load: crossfade new image over the old one
+      const preload = new Image();
+      preload.onload = () => {
+        const overlay = document.createElement('img');
+        overlay.className = 'tile-crossfade-overlay';
+        overlay.src = data.jpgUrl;
+        imageWrap.appendChild(overlay);
+
+        function finishCrossfade() {
+          jpgImg.src = data.jpgUrl;
+          if (data.gifUrl) gifImg.src = data.gifUrl;
+          overlay.remove();
+          if (loading) loading.hidden = true;
+        }
+
+        // Trigger the CSS transition after the element is in the DOM
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => { overlay.style.opacity = '1'; });
+        });
+
+        // Clean up after transition (with fallback timeout)
+        const fallback = setTimeout(finishCrossfade, 1200);
+        overlay.addEventListener('transitionend', () => {
+          clearTimeout(fallback);
+          finishCrossfade();
+        }, { once: true });
+      };
+      preload.onerror = () => {
+        if (loading) loading.hidden = true;
+        showTileError(tile, webcam);
+      };
+      preload.src = data.jpgUrl;
+    }
   } catch {
     if (loading) loading.hidden = true;
     showTileError(tile, webcam);
@@ -771,8 +825,13 @@ function updateEmptyState() {
 
 // --- Refresh ---
 
-function refreshAllImages() {
-  webcams.forEach(webcam => loadTileImage(webcam));
+async function refreshAllImages() {
+  for (let i = 0; i < webcams.length; i++) {
+    if (i > 0) {
+      await new Promise(resolve => setTimeout(resolve, 10000));
+    }
+    loadTileImage(webcams[i]);
+  }
   updateRefreshInfo();
 }
 

--- a/webcam-image-viewer/index.html
+++ b/webcam-image-viewer/index.html
@@ -720,20 +720,22 @@ async function loadTileImage(webcam) {
   const existingError = tile.querySelector('.tile-error-overlay');
   if (existingError) existingError.remove();
 
-  const hasExistingImage = jpgImg.hasAttribute('src');
-  if (!hasExistingImage && loading) loading.hidden = false;
+  const hasLoadedImage = jpgImg.dataset.loaded === 'true';
+  if (!hasLoadedImage && loading) loading.hidden = false;
 
   try {
     const data = await fetchSnapshot(webcam.snapshotUrl);
     tileData.set(webcam.id, data);
 
-    if (!hasExistingImage) {
+    if (!hasLoadedImage) {
       // First load: fade image in once loaded
       jpgImg.style.opacity = '0';
       jpgImg.src = data.jpgUrl;
       if (data.gifUrl) gifImg.src = data.gifUrl;
+      else gifImg.removeAttribute('src');
 
       jpgImg.onload = () => {
+        jpgImg.dataset.loaded = 'true';
         if (loading) loading.hidden = true;
         requestAnimationFrame(() => { jpgImg.style.opacity = '1'; });
       };
@@ -753,6 +755,7 @@ async function loadTileImage(webcam) {
         function finishCrossfade() {
           jpgImg.src = data.jpgUrl;
           if (data.gifUrl) gifImg.src = data.gifUrl;
+          else gifImg.removeAttribute('src');
           overlay.remove();
           if (loading) loading.hidden = true;
         }
@@ -825,14 +828,21 @@ function updateEmptyState() {
 
 // --- Refresh ---
 
+let isRefreshing = false;
 async function refreshAllImages() {
-  for (let i = 0; i < webcams.length; i++) {
-    if (i > 0) {
-      await new Promise(resolve => setTimeout(resolve, 10000));
+  if (isRefreshing) return;
+  isRefreshing = true;
+  try {
+    for (let i = 0; i < webcams.length; i++) {
+      if (i > 0) {
+        await new Promise(resolve => setTimeout(resolve, 5000));
+      }
+      loadTileImage(webcams[i]);
     }
-    loadTileImage(webcams[i]);
+    updateRefreshInfo();
+  } finally {
+    isRefreshing = false;
   }
-  updateRefreshInfo();
 }
 
 function updateRefreshInfo() {


### PR DESCRIPTION
## Summary
Enhanced the image loading experience in the webcam viewer by adding smooth fade-in animations for initial loads and crossfade transitions for subsequent image refreshes. Also implemented staggered refresh timing to reduce server load.

## Key Changes
- **First load fade-in**: Images now fade in smoothly (opacity 0→1) when first loaded, with the loading overlay hidden only after the image is ready
- **Subsequent load crossfade**: When refreshing existing images, new images crossfade over old ones using an overlay element with CSS transitions, providing a seamless visual update
- **Improved loading state handling**: Loading overlay is only shown on first load, not on subsequent refreshes
- **Staggered refresh timing**: `refreshAllImages()` now loads images sequentially with a 10-second delay between each webcam, reducing concurrent server requests
- **Added CSS styles**: New `.tile-image-wrap img:not([src])` rule to hide unloaded images and `.tile-crossfade-overlay` class for the crossfade animation

## Implementation Details
- First load uses a simple opacity transition with `onload` callback
- Subsequent loads preload the image before creating an overlay element to avoid flickering
- Crossfade uses `requestAnimationFrame` double-call to ensure CSS transition is triggered after DOM insertion
- Includes fallback timeout (1200ms) for transition cleanup in case `transitionend` event doesn't fire
- Image preloading prevents visual glitches and ensures smooth transitions

https://claude.ai/code/session_01QvLgYtNJ6ApZN1ajiJRLC3